### PR TITLE
pipe/sh: simplify transpile script

### DIFF
--- a/pipe/sh/package-scripts.js
+++ b/pipe/sh/package-scripts.js
@@ -8,8 +8,8 @@ const { ROOT_DIR, OUT_DIR, CONFIG_DIR, EXT } = require('./project.config');
 const DOT_EXT = '.' + EXT.replace(/,/g, ',.');
 
 const docker = `docker run -ti --rm --name go-sh-build \
---mount type=bind,source=${ROOT_DIR},target=/go/src/app \
-golang:1.11.5-alpine /bin/sh -x /go/src/app/transpile/docker.sh`;
+--mount type=bind,source=${ROOT_DIR},target=/go/app \
+golang:1.11.5-alpine /bin/sh -x /go/app/transpile/docker.sh`;
 
 process.env.LOG_LEVEL = 'disable';
 module.exports = scripts({


### PR DESCRIPTION
Disable CGO, which means we don't need to install gcc.

We only need to clone sh; gopherjs can be resolved via go.mod, just like
upstream does.

Finally, use the v3 branch of the sh project, as that contains the
changes we need.