### PR TITLE
pipe/sh: use the new _js/go.mod file from upstream

### DIFF
--- a/pipe/sh/transpile/docker.sh
+++ b/pipe/sh/transpile/docker.sh
@@ -14,19 +14,16 @@ export CGO_ENABLED=0
 # Shallow clone v3 of the sh package.
 # TODO: pin a version tag or commit hash instead
 git clone --depth=1 -b master.v3 https://github.com/mvdan/sh
-cd /go/sh
 
-# Install the myitcv/gopherjs version pinned by sh v3.
-go install github.com/gopherjs/gopherjs
+# Use the GopherJS and x/tools versions from _js/go.mod, via 'go run' further
+# down.
+cd /go/sh/_js
 
 # Transpile, using sh v3's go.mod to resolve deps.
 # if desired, add -m flag for gopherjs output minification
-gopherjs build -o /go/app/build/src/gopher.js /go/app/transpile/main.go
+go run github.com/gopherjs/gopherjs build -o /go/app/build/src/gopher.js /go/app/transpile/main.go
 
-# Get the API dump in JSON. We need a newer x/tools, since gopherjs pulls in an
-# old version, and the sh module doesn't require any x/tools version.
-cd /go/sh/syntax
-go get -u -d golang.org/x/tools@v0.0.0-20190221204921-83362c3779f5
+# Get the API dump in JSON.
 go run api_dump.go > /go/app/build/lib/sh.types.json
 
 cd /go/app/build


### PR DESCRIPTION
This file now locks in the versions of GopherJS and x/tools necessary to
transpile the project and get the API dump. This means we no longer have
to separately lock a version of x/tools via 'go get -u', as long as we
cd into the right directory.